### PR TITLE
fix: fixes lambda version already exists

### DIFF
--- a/bin/stacks/routing-lambda-stack.ts
+++ b/bin/stacks/routing-lambda-stack.ts
@@ -87,7 +87,9 @@ export class RoutingLambdaStack extends cdk.NestedStack {
         minify: true,
         sourceMap: true,
       },
-      description: 'Routing Lambda',
+      // adding this to bypass version already exists error
+      // https://github.com/aws/aws-cdk/issues/5334
+      description: `Routing Lambda - Generated on: ${new Date().toISOString()}`,
       environment: {
         VERSION: '5',
         NODE_OPTIONS: '--enable-source-maps',


### PR DESCRIPTION
* after changes to build process, lambda nested stack failed to update
* added temp fix to generate new lambda version for update
* this is a bug in CDK, issue link added in change comment