### PR TITLE
fix: missing cache duration variable in build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
+---- **_Fasset Info Start_** ----
 
- ---- **Fasset Info Start** ----
 ## Build Steps
 
-This repo is forked from uniswap. Deploy it in US-EAST-2 and call the endpoints from wallet-api. 
-Goal is to stay in sync with the base repo without making too many changes in this code. 
+This repo is forked from uniswap. Deploy it in US-EAST-2 and call the endpoints from wallet-api.
+Goal is to stay in sync with the base repo without making too many changes in this code.
 
-Pushing or updating to main will trigger code build. 
-Currently it deploys to non-prod for testing and later we will update the [buildspec/build.yml](./buildspec/build.yml) to deploy in prod. 
+Pushing or updating to main will trigger code build.
+Currently it deploys to non-prod and prod using triggers on main branch.
 
-Note: `INITIAL_RUN_BOOTSTRAP` is defined in non-prod as `/prod/general/uniswap-routing-api/...`
+### Generate templates locally
 
----- **Fasset Info End** ----
+```sh
+npm run build
+ENV_NAME=dev CACHING_LAMBDA_SCHEDULE_MINS=60 cdk synth
+```
+
+---- **_Fasset Info End_** ----
 
 # Uniswap Routing API
 

--- a/bin/config.ts
+++ b/bin/config.ts
@@ -27,7 +27,9 @@ function getEnvironmentVariables(scope: Construct, env: string, secret: sm.ISecr
     TENDERLY_PROJECT: '',
     TENDERLY_ACCESS_KEY: '',
     API_KEY: getSecretParameterValue(secret, 'UNISWAP_ROUTING_API_KEY'),
-    CACHING_LAMBDA_SCHEDULE_MINS: getParameter(scope, `/${env}/general/wallet-api/CACHING_LAMBDA_SCHEDULE_MINS`),
+    CACHING_LAMBDA_SCHEDULE_MINS:
+      process.env.CACHING_LAMBDA_SCHEDULE_MINS ??
+      getParameter(scope, `/${env}/general/wallet-api/CACHING_LAMBDA_SCHEDULE_MINS`),
   }
 }
 

--- a/buildspec/build.yml
+++ b/buildspec/build.yml
@@ -8,10 +8,11 @@ phases:
   pre_build:
     commands:
       - INITIAL_RUN_BOOTSTRAP=$(aws ssm get-parameter --name /dev/general/uniswap-routing-api/INITIAL_RUN_BOOTSTRAP --with-decryption --query "Parameter.{Value:Value}" --output text)
+      - CACHE_SCHEDULE=$(aws ssm get-parameter --name /dev/general/uniswap-routing-api/CACHING_LAMBDA_SCHEDULE_MINS --with-decryption --query "Parameter.{Value:Value}" --output text)
   build:
     commands:
       - npm install -g aws-cdk
       - npm install
       - npm run build
       - if [ "$INITIAL_RUN_BOOTSTRAP" = "true" ]; then ENV_NAME=dev cdk bootstrap aws://683031685817/us-east-2; fi
-      - ENV_NAME=dev cdk deploy RoutingAPIStack --require-approval never --verbose
+      - ENV_NAME=dev CACHING_LAMBDA_SCHEDULE_MINS=$CACHE_SCHEDULE cdk deploy RoutingAPIStack --require-approval never --verbose

--- a/buildspec/prod-build.yml
+++ b/buildspec/prod-build.yml
@@ -8,10 +8,11 @@ phases:
   pre_build:
     commands:
       - INITIAL_RUN_BOOTSTRAP=$(aws ssm get-parameter --name /prod/general/uniswap-routing-api/INITIAL_RUN_BOOTSTRAP --with-decryption --query "Parameter.{Value:Value}" --output text)
+      - CACHE_SCHEDULE=$(aws ssm get-parameter --name /prod/general/uniswap-routing-api/CACHING_LAMBDA_SCHEDULE_MINS --with-decryption --query "Parameter.{Value:Value}" --output text)
   build:
     commands:
       - npm install -g aws-cdk
       - npm install
       - npm run build
       - if [ "$INITIAL_RUN_BOOTSTRAP" = "true" ]; then ENV_NAME=prod cdk bootstrap aws://024147136615/us-east-2; fi
-      - ENV_NAME=prod cdk deploy RoutingAPIStack --require-approval never --verbose
+      - ENV_NAME=prod CACHING_LAMBDA_SCHEDULE_MINS=$CACHE_SCHEDULE cdk deploy RoutingAPIStack --require-approval never --verbose


### PR DESCRIPTION
* synth performs static analysis & cannot get dynamic value from SSM
* reads SSM value in build.yml and passes it on
* updates docs